### PR TITLE
Implemented Markdown and therefore code highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-emoji-render": "1.2.4",
     "react-i18next": "10.11.4",
     "react-linkify": "1.0.0-alpha",
+    "react-markdown": "^5.0.3",
     "react-native": "github:jitsi/react-native#891986ec5ecaef65d1c8a7fe472f86cf84fe7551",
     "react-native-background-timer": "2.4.0",
     "react-native-calendar-events": "github:jitsi/react-native-calendar-events#df48ecdc4e1e90c5352f803ddbab1fa7269b74a7",

--- a/react/features/chat/components/web/ChatMessage.js
+++ b/react/features/chat/components/web/ChatMessage.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { toArray } from 'react-emoji-render';
-
+import ReactMarkdown from 'react-markdown';
 
 import { translate } from '../../../base/i18n';
 import { Linkify } from '../../../base/react';
@@ -16,6 +16,20 @@ import PrivateMessageButton from '../PrivateMessageButton';
  * Renders a single chat message.
  */
 class ChatMessage extends AbstractChatMessage<Props> {
+
+    /**
+     * Checks if the given string is a valid URL.
+     *
+     * @param {string} input - The inputstring given.
+     * @returns {boolean} True when the input is a valid string.
+     */
+    isValidUrl(input) {
+        const res = input.match(
+            /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&/=]*)/g);
+
+        return res !== null;
+    }
+
     /**
      * Implements React's {@link Component#render()}.
      *
@@ -31,7 +45,12 @@ class ChatMessage extends AbstractChatMessage<Props> {
 
         content.forEach(i => {
             if (typeof i === 'string') {
-                processedMessage.push(<Linkify key = { i }>{ i }</Linkify>);
+                if (this.isValidUrl(i)) {
+                    processedMessage.push(<Linkify key = { i }>{i}</Linkify>);
+                } else {
+                    processedMessage.push(<ReactMarkdown key = { i }>{ i }</ReactMarkdown>);
+                }
+
             } else {
                 processedMessage.push(i);
             }


### PR DESCRIPTION
When implementing code highlighting, I noticed there was also no Markdown support (such as \*..\* for italic and such). I saw an issue opened earlier for this but it went stale and was automatically closed (https://github.com/jitsi/jitsi-meet/issues/5536). Therefore I decided to hit two birds with one stone and implement a markdown parser (and thereby implement code highlighting for the chat as well). 

I decided to implement an existing library, as I think this would be the cleanest way to do this. Implementing this ourselves would require to create a markdown parser from scratch, which would be prune to errors and be a hassle to maintain. 